### PR TITLE
Let the parent container define width and height of the svg

### DIFF
--- a/src/components/Chart/index.vue
+++ b/src/components/Chart/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="chart" ref="chartEl">
     <svg
-      :width="size.width"
-      :height="size.height"
+      width="100%"
+      height="100%"
       :viewBox="`0 0 ${size.width} ${size.height}`"
       @mousemove="onMouseMove"
       @mouseleave="onMouseOut"


### PR DESCRIPTION
With this setting the parent container is able to scale the svg while the drawing is made on a larger canvas.