### PR TITLE
Add sorting option to pie chart

### DIFF
--- a/dev/pages/Main.vue
+++ b/dev/pages/Main.vue
@@ -149,7 +149,7 @@
           :size="{ width: 400, height: 400 }"
         >
           <template #layers>
-            <Pie :dataKeys="['name', 'avg']" />
+            <Pie :dataKeys="['name', 'avg']" sort="custom" :sort-func="randomSort" />
             <!-- </Group> -->
           </template>
           <template #widgets>
@@ -285,6 +285,10 @@ export default defineComponent({
       console.log('click me')
     }
 
+    function randomSort(a: number, b: number) {
+      return a === null || b === null ? NaN : Math.random() * a - b
+    }
+
     return {
       data,
       data2,
@@ -296,7 +300,8 @@ export default defineComponent({
       add,
       updateConfig,
       test,
-      console
+      console,
+      randomSort
     }
   }
 })

--- a/src/components/Pie/index.vue
+++ b/src/components/Pie/index.vue
@@ -20,11 +20,12 @@
 import { computed, defineComponent, ref, watch } from 'vue'
 import { useMouse, useChart } from '@/hooks'
 import Layer from '../Layer/index.vue'
-import { Arc } from '@/types'
+import { Arc, PieSort } from '@/types'
 import { kebabize, mapKeys } from '@/utils'
 import { pie, arc } from 'd3-shape'
 import { scaleOrdinal } from 'd3-scale'
 import { pointer } from 'd3-selection'
+import { ascending, descending, Primitive } from 'd3-array'
 
 export default defineComponent({
   name: 'PieLayer',
@@ -37,6 +38,15 @@ export default defineComponent({
     dataKeys: {
       type: Object as () => [string, string],
       required: true
+    },
+    sort: {
+      type: PieSort,
+      default: 'desc',
+      required: false
+    },
+    sortFunc: {
+      type: Function,
+      required: false
     }
   },
   setup(props) {
@@ -70,10 +80,19 @@ export default defineComponent({
 
     const transform = ref(`translate(${size.value + chart.canvas.x}, ${size.value + chart.canvas.y})`)
 
+    let pieSort: any
+    switch (props.sort) {
+      case 'desc': pieSort = descending; break
+      case 'asc': pieSort = ascending; break
+      case 'none': pieSort = null; break
+      case 'custom': pieSort = props.sortFunc ?? null; break
+      default: pieSort = null
+    }
+
     function updatePie() {
       // const key = chart.getKeys(1)
       const data = chart.getData([props.dataKeys[1]])
-      arcs.value = pie()(data)
+      arcs.value = pie().sort(pieSort)(data)
     }
 
     function getColor(index: number) {

--- a/src/components/Pie/index.vue
+++ b/src/components/Pie/index.vue
@@ -25,7 +25,7 @@ import { kebabize, mapKeys } from '@/utils'
 import { pie, arc } from 'd3-shape'
 import { scaleOrdinal } from 'd3-scale'
 import { pointer } from 'd3-selection'
-import { ascending, descending, Primitive } from 'd3-array'
+import { ascending, descending } from 'd3-array'
 
 export default defineComponent({
   name: 'PieLayer',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,6 +3,9 @@ import { PieArcDatum } from 'd3-shape'
 
 export type Arc = PieArcDatum<number | { valueOf(): number }>
 
+export type PieSortType = 'desc' | 'asc' | 'none' | 'custom'
+export const PieSort = String as () => PieSortType
+
 export interface Point {
   x: number
   y: number


### PR DESCRIPTION
Hi, me again :)

Thanks for merging my previous PR so quickly!

I have yet another addition, a smaller one this time. D3 apparently automatically sorts the pie wedges in a descending order, but I need a custom sorting option. I have added a few options:

- desc: regular descending sort
- asc: regular ascending sort
- none: no ordering at all
- custom: use a custom provided sort function