### PR TITLE
fix: remove console log statement

### DIFF
--- a/src/components/Chart/index.vue
+++ b/src/components/Chart/index.vue
@@ -165,7 +165,6 @@ export default defineComponent({
 
     onUnmounted(() => {
       resizeObserver.disconnect()
-      console.log('unmounted')
     })
 
     function onMouseOut() {


### PR DESCRIPTION
Removes the  `unmounted` log from the chart component. We were seeing this log in our application and don't believe the log serves any purpose.